### PR TITLE
Update For urllib2 Error 32 Broken Pipe on uploading single file havi…

### DIFF
--- a/backblazeb2/backblazeb2.py
+++ b/backblazeb2/backblazeb2.py
@@ -293,6 +293,9 @@ class BackBlazeB2(object):
                           path)  # Make sure Windows paths are converted.
         filename = re.sub('^/', '', filename)
         filename = re.sub('//', '/', filename)
+        #All the whitespaces in the filename should be converted to %20
+        if " " in filename:
+            filename = filename.replace(" ", "%20")
         # TODO: Figure out URL encoding issue
         filename = unicode(filename, "utf-8")
         headers = {


### PR DESCRIPTION
…ng whitespace in filename

If the filename has spaces in them like ab cd.* then B2 would just close the connection resulting in Broken Pipe Error. According to the Documentation if spaces are converted to "%20" then it would be uploaded to the B2 without any errors.

Link to Document: https://www.backblaze.com/b2/docs/b2_upload_file.html